### PR TITLE
Improve quiz style responsiveness

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -270,6 +270,13 @@ nav ul li a {
   font-size: 18px;
 }
 
+/* Iframe del quiz */
+.quiz-frame {
+  width: 100%;
+  height: 80vh;
+  border: none;
+}
+
 /* FOOTER */
 footer {
   text-align: center;

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <li id="home"><a href="#home">Home</a></li>
         <li id="servizi"><a href="#servizi">Servizi</a></li>
         <li id="percorsi"><a href="#percorsi">Percorsi</a></li>
+        <li id="quiz"><a href="#quiz">Quiz</a></li>
         <li id="prenotazione"><a href="#prenotazione">Prenotazione</a></li>
         <li id="contatti"><a href="#contatti">Contatti</a></li>
         <li id="diario"><a href="#diario">Diario</a></li>
@@ -78,6 +79,14 @@
     <div class="section-content">
       <h2 class="fade-in"><strong>Percorsi personalizzati</strong></h2>
       <p class="fade-in">Ogni passo avanti è una conquista. Nulla è impossibile.</p>
+    </div>
+  </section>
+
+  <!-- SEZIONE QUIZ con id="quiz" -->
+  <section class="section section-dark" id="quiz">
+    <div class="section-content">
+      <h2 class="fade-in"><strong>Quiz</strong></h2>
+      <iframe src="quiz.html" class="quiz-frame"></iframe>
     </div>
   </section>
 

--- a/quiz.html
+++ b/quiz.html
@@ -4,22 +4,41 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Quiz Interattivo: Terapia Psicologica</title>
+<!-- Font Baloo 2 per coerenza con l'indice -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;800&display=swap" rel="stylesheet">
 <style>
-    body { font-family: Arial, Helvetica, sans-serif; max-width: 900px; margin: auto; padding: 1rem; background-color: #f4f7f9; }
-    h1, h2, h3 { text-align: center; color: #2c3e50; }
+    body {
+      font-family: 'Baloo 2', Arial, Helvetica, sans-serif;
+      max-width: 900px;
+      margin: auto;
+      padding: 1rem;
+      background-color: #1a1a1a;
+      color: #fff;
+    }
+    h1, h2, h3 { text-align: center; color: #fff; }
     
-    #quiz-wrapper { border: 1px solid #ddd; background: #fff; border-radius: 8px; padding: 1.5rem; box-shadow: 0 4px 15px rgba(0,0,0,0.05); }
+    #quiz-wrapper {
+      border: 1px solid #ddd;
+      background: #000;
+      border-radius: 8px;
+      padding: 1.5rem;
+      box-shadow: 0 4px 15px rgba(0,0,0,0.5);
+      max-width: 800px;
+      margin: auto;
+    }
 
     .progress-container { margin-bottom: 1.5rem; }
-    .progress-label { font-size: 0.9rem; color: #555; margin-bottom: 0.3rem; }
+    .progress-label { font-size: 0.9rem; color: #ccc; margin-bottom: 0.3rem; }
     .progress-bar { width: 100%; background-color: #e0e0e0; border-radius: 4px; overflow: hidden; height: 18px; }
     .progress-bar-inner { height: 100%; width: 0%; background-color: #3498db; transition: width 0.4s ease; text-align: center; color: white; font-size: 0.8rem; line-height: 18px; }
     .progress-bar-inner.total { background-color: #2ecc71; }
 
     .question { margin-bottom: 1.2rem; }
-    .question p { margin: .4rem 0 .8rem; font-weight: bold; font-size: 1.2em; color: #333; }
+    .question p { margin: .4rem 0 .8rem; font-weight: bold; font-size: 1.2em; color: #fff; }
     label { display: block; margin: .5rem 0; padding: 0.8rem; border: 1px solid #ccc; border-radius: 5px; cursor: pointer; transition: background-color 0.2s, border-color 0.2s; }
-    label:hover { background-color: #f5f5f5; }
+    label:hover { background-color: #333; }
     input[type="radio"] { margin-right: 10px; }
     input[type="radio"]:checked + span { font-weight: bold; }
 
@@ -31,7 +50,7 @@
     .nav-button#next-q-btn:disabled { background-color: #bdc3c7; cursor: not-allowed; }
     .nav-button#end-q-btn { background-color: #e67e22; color: white; }
     .nav-button#resume-q-btn { background-color: #3498db; color: white; margin: 1rem auto; display: block; }
-    .button-note { font-size: 0.8rem; color: #777; margin-top: 4px; }
+    .button-note { font-size: 0.8rem; color: #bbb; margin-top: 4px; }
 
     #result-container { font-size: 1.1rem; }
     .explanation { margin-top: .5rem; padding: .8rem; background: #fffbe6; border-left: 4px solid #f1c40f; }
@@ -50,6 +69,20 @@
     #admin-user-list li { padding: 0.75rem; border: 1px solid #ddd; margin-bottom: 5px; cursor: pointer; border-radius: 4px; }
     #admin-user-list li:hover, #admin-user-list li.active { background-color: #e9ecef; }
     #admin-result-details { width: 70%; border-left: 1px solid #ddd; padding-left: 2rem; }
+
+    /* Responsive layout */
+    @media (max-width: 600px) {
+      #navigation-container {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .nav-buttons {
+        flex-direction: column;
+      }
+      .nav-button {
+        margin-bottom: 0.5rem;
+      }
+    }
 
 </style>
 </head>


### PR DESCRIPTION
## Summary
- refine quiz page with same font as index
- match quiz background to site dark theme
- tweak colors for dark theme
- add responsive layout for navigation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685167f672dc832f909dace48192f5d3