### PR TITLE
Fix script init for Next.js pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+package-lock.json

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", function() {
+function initSiteScripts() {
 
   const fadeInElements = document.querySelectorAll(".fade-in");
   const sections       = document.querySelectorAll(".section");
@@ -189,4 +189,10 @@ document.querySelectorAll("nav ul li a").forEach(link => {
 
   // Avvio
   checkVisibility();
-});
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initSiteScripts);
+} else {
+  initSiteScripts();
+}


### PR DESCRIPTION
## Summary
- run client scripts even when DOMContentLoaded already fired
- add `.gitignore`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a88a98be8832f93d5dd113e818319